### PR TITLE
Make $().remodal() always return an instance

### DIFF
--- a/src/jquery.remodal.js
+++ b/src/jquery.remodal.js
@@ -359,6 +359,8 @@
                     $elem.attr("data-" + pluginName + "-id") === location.hash.substr(1)) {
                     instance.open();
                 }
+            } else {
+                instance = $[pluginName].lookup[$elem.data(pluginName)];
             }
         });
 


### PR DESCRIPTION
Make it return Remodal instance not only in first time, so that code like this might be safely used multiple times:

$('#popup').remodal().open();
