### PR TITLE
Avoid jump to top of page

### DIFF
--- a/src/jquery.remodal.js
+++ b/src/jquery.remodal.js
@@ -103,7 +103,7 @@
             paddingRight = parseInt($body.css("padding-right"), 10) + getScrollbarWidth();
 
         $body.css("padding-right", paddingRight + "px");
-        $("html, body").addClass(pluginName + "-is-locked");
+        $("html").addClass(pluginName + "-is-locked");
     }
 
     /**


### PR DESCRIPTION
Not setting the `-is-locked` class to body will avoid the scroll to the top of the page when a remodal is opened.
The workaround `html, body { overflow: auto !important; margin: 0; }` has side effects causing lazy loading on some jQuery plugin not to work.