### PR TITLE
Add baseClass option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ You can pass additional options by the `data-remodal-options` attribute.
 </div>
 ```
 
+#### namespace
+`Default: "remodal"`
+
+(String) Base HTML class for your modals. CSS theme will need to be updated to reflect this.
+
 #### hashTracking
 `Default: true`
 

--- a/src/jquery.remodal.js
+++ b/src/jquery.remodal.js
@@ -7,6 +7,7 @@
      */
     var pluginName = "remodal",
         defaults = {
+            namespace: pluginName,
             hashTracking: true,
             closeOnConfirm: true,
             closeOnCancel: true,
@@ -103,7 +104,7 @@
             paddingRight = parseInt($body.css("padding-right"), 10) + getScrollbarWidth();
 
         $body.css("padding-right", paddingRight + "px");
-        $("html").addClass(pluginName + "-is-locked");
+        $("html").addClass(defaults.namespace + "-is-locked");
     }
 
     /**
@@ -117,7 +118,7 @@
             paddingRight = parseInt($body.css("padding-right"), 10) - getScrollbarWidth();
 
         $body.css("padding-right", paddingRight + "px");
-        $("html").removeClass(pluginName + "-is-locked");
+        $("html").removeClass(defaults.namespace + "-is-locked");
     }
 
     /**
@@ -171,25 +172,26 @@
 
         // Build DOM
         remodal.$body = $(document.body);
-        remodal.$overlay = $("." + pluginName + "-overlay");
+        remodal.$overlay = $("." + remodal.settings.namespace + "-overlay");
 
         if (!remodal.$overlay.length) {
-            remodal.$overlay = $("<div>").addClass(pluginName + "-overlay");
+            remodal.$overlay = $("<div>").addClass(remodal.settings.namespace + "-overlay");
             remodal.$body.append(remodal.$overlay);
         }
 
-        remodal.$bg = $("." + pluginName + "-bg");
-        remodal.$closeButton = $("<a href='#'></a>").addClass(pluginName + "-close");
-        remodal.$wrapper = $("<div>").addClass(pluginName + "-wrapper");
+        remodal.$bg = $("." + remodal.settings.namespace + "-bg");
+        remodal.$closeButton = $("<a href='#'></a>")
+                               .addClass(remodal.settings.namespace + "-close");
+        remodal.$wrapper = $("<div>").addClass(remodal.settings.namespace + "-wrapper");
         remodal.$modal = $modal;
-        remodal.$modal.addClass(pluginName);
+        remodal.$modal.addClass(remodal.settings.namespace);
         remodal.$modal.css("visibility", "visible");
 
         remodal.$modal.append(remodal.$closeButton);
         remodal.$wrapper.append(remodal.$modal);
         remodal.$body.append(remodal.$wrapper);
-        remodal.$confirmButton = remodal.$modal.find("." + pluginName + "-confirm");
-        remodal.$cancelButton = remodal.$modal.find("." + pluginName + "-cancel");
+        remodal.$confirmButton = remodal.$modal.find("." + remodal.settings.namespace + "-confirm");
+        remodal.$cancelButton = remodal.$modal.find("." + remodal.settings.namespace + "-cancel");
 
         // Calculate timeouts
         tdOverlay = getTransitionDuration(remodal.$overlay);
@@ -199,14 +201,14 @@
         remodal.td = tdBg > remodal.td ? tdBg : remodal.td;
 
         // Add close button event listener
-        remodal.$closeButton.bind("click." + pluginName, function(e) {
+        remodal.$closeButton.bind("click." + remodal.settings.namespace, function(e) {
             e.preventDefault();
 
             remodal.close();
         });
 
         // Add cancel button event listener
-        remodal.$cancelButton.bind("click." + pluginName, function(e) {
+        remodal.$cancelButton.bind("click." + remodal.settings.namespace, function(e) {
             e.preventDefault();
 
             remodal.$modal.trigger("cancel");
@@ -217,7 +219,7 @@
         });
 
         // Add confirm button event listener
-        remodal.$confirmButton.bind("click." + pluginName, function(e) {
+        remodal.$confirmButton.bind("click." + remodal.settings.namespace, function(e) {
             e.preventDefault();
 
             remodal.$modal.trigger("confirm");
@@ -228,17 +230,17 @@
         });
 
         // Add keyboard event listener
-        $(document).bind("keyup." + pluginName, function(e) {
+        $(document).bind("keyup." + remodal.settings.namespace, function(e) {
             if (e.keyCode === 27 && remodal.settings.closeOnEscape) {
                 remodal.close();
             }
         });
 
         // Add overlay event listener
-        remodal.$wrapper.bind("click." + pluginName, function(e) {
+        remodal.$wrapper.bind("click." + remodal.settings.namespace, function(e) {
             var $target = $(e.target);
 
-            if (!$target.hasClass(pluginName + "-wrapper")) {
+            if (!$target.hasClass(remodal.settings.namespace + "-wrapper")) {
                 return;
             }
 
@@ -277,7 +279,7 @@
         if (current && current !== remodal) {
             current.$overlay.hide();
             current.$wrapper.hide();
-            current.$body.removeClass(pluginName + "-is-active");
+            current.$body.removeClass(remodal.settings.namespace + "-is-active");
         }
 
         current = remodal;
@@ -287,7 +289,7 @@
         remodal.$wrapper.show();
 
         setTimeout(function() {
-            remodal.$body.addClass(pluginName + "-is-active");
+            remodal.$body.addClass(remodal.settings.namespace + "-is-active");
 
             setTimeout(function() {
                 remodal.busy = false;
@@ -323,7 +325,7 @@
             $(window).scrollTop(scrollTop);
         }
 
-        remodal.$body.removeClass(pluginName + "-is-active");
+        remodal.$body.removeClass(remodal.settings.namespace + "-is-active");
 
         setTimeout(function() {
             remodal.$overlay.hide();
@@ -393,7 +395,7 @@
         // Auto initialization of modal windows.
         // They should have the 'remodal' class attribute.
         // Also you can write `data-remodal-options` attribute to pass params into the modal.
-        $(document).find("." + pluginName).each(function(i, container) {
+        $(document).find("." + defaults.namespace).each(function(i, container) {
             var $container = $(container),
                 options = $container.data(pluginName + "-options");
 

--- a/test/remodal_test.js
+++ b/test/remodal_test.js
@@ -230,6 +230,7 @@
 
     QUnit.test("Options parsing", function() {
         propEqual($inst2.settings, {
+            namespace: "remodal",
             hashTracking: false,
             closeOnConfirm: false,
             closeOnCancel: false,


### PR DESCRIPTION
This provides a `baseClass` option for overriding the default class of `.remodal`, allowing more flexibility over how the plugin CSS is integrated in to a codebase.

In my case for instance, I'm loading a modified/cut down version of the CSS theme written in Stylus as a [SUIT](http://suitcss.github.io/) component integrated in to my build system, rather than simply referencing your [full theme stylesheet](https://github.com/VodkaBears/Remodal/blob/master/dist/jquery.remodal.css) and overriding. I'd like all my modals on the page to have the base class of `.Modal` instead of `.remodal` to comply with [SUIT's naming conventions](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md#ComponentName).

This means I can now load only your javascript file via Bower, with my main stylesheet including this custom theme.

Whilst some users may not choose to take this extra integration step, providing the option is useful.