### PR TITLE
Update jquery.remodal.css

### DIFF
--- a/src/jquery.remodal.css
+++ b/src/jquery.remodal.css
@@ -51,7 +51,7 @@ html.remodal-is-locked {
 .remodal-wrapper:after {
     display: inline-block;
 
-    height: 100%;
+    height: auto;
     margin-left: -0.05em;
 
     content: "";


### PR DESCRIPTION
Из за этого свойства - на мобильном можно было проскролить попап за верхнюю границу экрана. 
Приведу скрины с проекта
Вот на этом месте скролить дальше по идее нельзя http://minus.com/lFqqTnY3d1S5B
Но из за этого свойства - происходит так http://minus.com/lbrGpTEwjof3i8