### PR TITLE
Fix double locking/unlocking issue

### DIFF
--- a/src/jquery.remodal.js
+++ b/src/jquery.remodal.js
@@ -98,13 +98,20 @@
      * @private
      */
     function lockScreen() {
-        var $body = $(document.body),
+        var $html = $("html"),
+            lockedClass = defaults.namespace + "-is-locked",
+            $body,
+            paddingRight;
+
+        if (!$html.hasClass(lockedClass)) {
+            $body = $(document.body);
 
             // Zepto does not support '-=', '+=' in the `css` method
             paddingRight = parseInt($body.css("padding-right"), 10) + getScrollbarWidth();
 
-        $body.css("padding-right", paddingRight + "px");
-        $("html").addClass(defaults.namespace + "-is-locked");
+            $body.css("padding-right", paddingRight + "px");
+            $html.addClass(lockedClass);
+        }
     }
 
     /**
@@ -112,13 +119,20 @@
      * @private
      */
     function unlockScreen() {
-        var $body = $(document.body),
+        var $html = $("html"),
+            lockedClass = defaults.namespace + "-is-locked",
+            $body,
+            paddingRight;
+
+        if ($html.hasClass(lockedClass)) {
+            $body = $(document.body);
 
             // Zepto does not support '-=', '+=' in the `css` method
             paddingRight = parseInt($body.css("padding-right"), 10) - getScrollbarWidth();
 
-        $body.css("padding-right", paddingRight + "px");
-        $("html").removeClass(defaults.namespace + "-is-locked");
+            $body.css("padding-right", paddingRight + "px");
+            $html.removeClass(lockedClass);
+        }
     }
 
     /**

--- a/test/remodal_test.js
+++ b/test/remodal_test.js
@@ -228,6 +228,25 @@
         location.hash = "#modal";
     });
 
+    QUnit.asyncTest("do not lock/unlock the scroll bar twice", function(assert) {
+        $("html").addClass("remodal-is-locked");
+        $(document.body).css("height", "10000px").css("padding-right", "20px");
+
+        $document.one("opened", "[data-remodal-id=modal]", function() {
+            assert.ok($("html").hasClass("remodal-is-locked"));
+            assert.ok(parseInt($(document.body).css("padding-right")) === 20);
+            $inst1.close();
+        });
+
+        $document.one("closed", "[data-remodal-id=modal]", function() {
+            assert.ok(!$("html").hasClass("remodal-is-locked"));
+            assert.ok(parseInt($(document.body).css("padding-right")) < 20);
+            QUnit.start();
+        });
+
+        location.hash = "#modal";
+    });
+
     QUnit.test("Options parsing", function() {
         propEqual($inst2.settings, {
             namespace: "remodal",


### PR DESCRIPTION
Hi,

When opening a second modal without closing the first one Remodal keeps on adding padding to the `body`.
Here's a quick PR that checks the `html` is locked/unlocked before locking/unlocking it for the second time.

Tests are included.

P.S. I had to move `$body` and `paddingRight ` declaration outside of the `if` because `jscs` wants a single `var` declaration per method and I really didn't want to initialize `$body` and `paddingRight` before the conditional for the performance reasons.