### PR TITLE
Fix Travis CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-csscomb": "^3.0.0",
     "grunt-githooks": "^0.3.1",
-    "grunt-jscs": "^1.2.0"
+    "grunt-jscs": "1.2.0"
   },
   "scripts": {
     "postinstall": "./node_modules/.bin/bower install; ./node_modules/.bin/grunt githooks",


### PR DESCRIPTION
Locking `grunt-jscs` to the last version that considers current `Gruntfile.js` style valid, which is 1.2.0.