### PR TITLE
Adding README section for wrappers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,14 @@ List:
 
 A modifier that is specified in the [options](#options) is added to the `.remodal`, `.remodal-overlay`, `.remodal-bg`, `.remodal-wrapper` classes.
 
+## Using with other javascript libraries
+
+Remodal has wrappers that make it easy to use with other javascript libraries:
+ 
+### Ember
+
+* [ember-remodal](https://github.com/sethbrasile/ember-remodal)
+
 ## License
 
 ```


### PR DESCRIPTION
This PR adds a _wrappers_ section to the Readme. This lists the wrappers done for another javascript libraries/frameworks.