### PR TITLE
add appendTo option

### DIFF
--- a/src/remodal.js
+++ b/src/remodal.js
@@ -70,7 +70,8 @@
     closeOnCancel: true,
     closeOnEscape: true,
     closeOnOutsideClick: true,
-    modifier: ''
+    modifier: '',
+    appendTo: null
   }, global.REMODAL_GLOBALS && global.REMODAL_GLOBALS.DEFAULTS);
 
   /**
@@ -497,6 +498,7 @@
    */
   function Remodal($modal, options) {
     var $body = $(document.body);
+    var $appendTo = $body;
     var remodal = this;
 
     remodal.settings = $.extend({}, DEFAULTS, options);
@@ -505,9 +507,13 @@
 
     remodal.$overlay = $('.' + namespacify('overlay'));
 
+    if (remodal.settings.appendTo !== null && remodal.settings.appendTo.length) {
+      $appendTo = $(remodal.settings.appendTo);
+    }
+
     if (!remodal.$overlay.length) {
       remodal.$overlay = $('<div>').addClass(namespacify('overlay') + ' ' + namespacify('is', STATES.CLOSED)).hide();
-      $body.append(remodal.$overlay);
+      $appendTo.append(remodal.$overlay);
     }
 
     remodal.$bg = $('.' + namespacify('bg')).addClass(namespacify('is', STATES.CLOSED));
@@ -527,7 +533,7 @@
         namespacify('is', STATES.CLOSED))
       .hide()
       .append(remodal.$modal);
-    $body.append(remodal.$wrapper);
+    $appendTo.append(remodal.$wrapper);
 
     // Add the event listener for the close button
     remodal.$wrapper.on('click.' + NAMESPACE, '[data-' + PLUGIN_NAME + '-action="close"]', function(e) {

--- a/test/remodal.html
+++ b/test/remodal.html
@@ -58,5 +58,11 @@
 <div class="remodal" data-remodal-id="!modal4/test">
   <a data-remodal-action="close" class="remodal-close"></a>
 </div>
+
+<div data-remodal-id="modal5">
+  <a data-remodal-action="close" class="remodal-close"></a>
+</div>
+
+<div id="target"></div>
 </body>
 </html>

--- a/test/remodal_test.js
+++ b/test/remodal_test.js
@@ -311,7 +311,8 @@
       closeOnCancel: false,
       closeOnEscape: false,
       closeOnOutsideClick: false,
-      modifier: 'without-animation with-test-class'
+      modifier: 'without-animation with-test-class',
+      appendTo: null
     }, 'options are correctly parsed');
   });
 
@@ -424,6 +425,27 @@
       assert.notOk($overlay.hasClass('without-animation with-test-class'), 'overlay has\'t the modifier');
       assert.ok($wrapper.hasClass('without-animation with-test-class'), 'wrapper still has the modifier');
       assert.ok($modal.hasClass('without-animation with-test-class'), 'modal still has the modifier');
+
+      QUnit.start();
+    });
+
+    remodal.open();
+  });
+
+  QUnit.asyncTest('"appendTo" option', function(assert) {
+    var $elem = $('[data-remodal-id=modal5]');
+    var $target = $('#target');
+    var remodal = $elem.remodal({
+      appendTo: $target
+    });
+
+    $document.one('opened', '[data-remodal-id=modal5]', function() {
+      var $wrapper = $('[data-remodal-id=modal5]').parent();
+      var $appendTo = $wrapper.parent();
+
+      assert.equal($appendTo.attr('id'), 'target', 'modal appended to target');
+
+      remodal.close();
 
       QUnit.start();
     });


### PR DESCRIPTION
Attach Remodal wrapper DOM element to something other than document.body.

The reasoning behind this is that in component based UI's using libraries like React in real-world applications it is necessary to integrate 3rd party DOM manipulation libraries with the component architecture and lifecycle. Not being able to attach the modal to a component violates principles behind component based UI design by bleeding abstractions across components and will make your application more difficult to reason about and test.

It is recommended that the DOM that is rendered by react should not be mutated otherwise when it comes to re-render the component it cannot reconcile the differences and throws an error. There are some circumstances where it is acceptable, and by making this change we can use the Remodal library in component-based UI's by simply opening and closing the modal in the lifecycle hooks.