### PR TITLE
Fix issue caused by calling remodal.close() when it is already closed

### DIFF
--- a/src/remodal.js
+++ b/src/remodal.js
@@ -630,7 +630,7 @@
     var remodal = this;
 
     // Check if the animation was completed
-    if (remodal.state === STATES.OPENING || remodal.state === STATES.CLOSING) {
+    if (remodal.state === STATES.OPENING || remodal.state === STATES.CLOSING || remodal.state === STATES.CLOSED) {
       return;
     }
 


### PR DESCRIPTION
Add check to remodal.prototype.close function to return; if remodal.state is already closed. Currently if remodal.close() is called multiple times the modal will hang in CLOSING and become unresponsive. Fixes #241 and #246  
