### PR TITLE
Fix function getScrollbarWidth

### DIFF
--- a/src/remodal.js
+++ b/src/remodal.js
@@ -202,7 +202,7 @@
    * @returns {Number}
    */
   function getScrollbarWidth() {
-    if ($(document.body).height() <= $(window).height()) {
+    if ($(document).height() <= $(window).height()) {
       return 0;
     }
 


### PR DESCRIPTION
In some cases **$(document.body).height()** gets the same height as **$(window).height()**
(for example if you use the "foundation framework", because it sets the body height to 100% because of the "Off-canvas"-component)
This will cause the content to move slightly to the right, because the function returns 0.

Change **$(document.body).height()** to **$(document).height()** solves this issue.
