### PR TITLE
Fixes the blurry text issue at animation end

### DIFF
--- a/src/remodal-default-theme.css
+++ b/src/remodal-default-theme.css
@@ -181,6 +181,7 @@
   }
   to {
     transform: none;
+    filter: blur(0);
 
     opacity: 1;
   }
@@ -194,6 +195,7 @@
   }
   to {
     transform: scale(0.95);
+    filter: blur(0);
 
     opacity: 0;
   }


### PR DESCRIPTION
Related to https://github.com/VodkaBears/Remodal/issues/204

I found out that adding `filter: blur(0)` fixes the problem with blurry text rendering after animation on Chrome.